### PR TITLE
"runner" style naive pubsub implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mwiczer/pubsub-demo
 
 go 1.22.3
+
+require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/main.go
+++ b/main.go
@@ -5,51 +5,9 @@ import (
 	"context"
 	"log"
 	"time"
+
+	"github.com/mwiczer/pubsub-demo/pubsub"
 )
-
-type pubSubRunner struct {
-	// Arrows in the type annotation protect us from accidentally writing back into the Publisher
-	Publisher   <-chan string
-	Subscribers []chan<- string
-}
-
-func (ps pubSubRunner) Run(ctx context.Context) {
-	i := 0
-	for {
-		var msg string
-		// Receive from publisher
-		select {
-		case msg = <-ps.Publisher:
-		case <-ctx.Done():
-			log.Printf("Exiting fanout goroutine: %v", ctx.Err())
-			return
-		}
-		i++
-		// Fanout
-		log.Printf("Forwarding message %d to subscribers...", i)
-		for _, subCh := range ps.Subscribers {
-			select {
-			case subCh <- msg:
-			case <-ctx.Done():
-				log.Printf("Exiting fanout goroutine: %v", ctx.Err())
-				return
-			}
-		}
-	}
-}
-
-// RunPubSub creates a publisher channel which, when written to, fans the message out to all provided subscribers.
-//
-// It spawns a goroutine to manage the fanout. The publisher channel is unbuffered, therefore it is throttled by the slowest subscriber.
-func RunPubSub(ctx context.Context, subscribers ...chan<- string) chan<- string {
-	publisher := make(chan string)
-	ps := pubSubRunner{
-		Publisher:   publisher,
-		Subscribers: subscribers,
-	}
-	go ps.Run(ctx)
-	return publisher
-}
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
@@ -58,7 +16,7 @@ func main() {
 
 	subCh1 := make(chan string)
 	subCh2 := make(chan string)
-	pubCh := RunPubSub(ctx, subCh1, subCh2)
+	pubCh := pubsub.RunPubSub(ctx, subCh1, subCh2)
 
 	// Listen for messages
 	go func(ctx context.Context) {

--- a/main.go
+++ b/main.go
@@ -12,19 +12,59 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	ch := make(chan string)
+	pubCh := make(chan string)
+	subCh1 := make(chan string)
+	subCh2 := make(chan string)
+	subscribers := []chan string{subCh1, subCh2}
+
+	// Fanout the messages:
+	go func(ctx context.Context) {
+		i := 0
+		for {
+			var msg string
+			select {
+			case msg = <-pubCh:
+			case <-ctx.Done():
+				log.Printf("Exiting fanout goroutine: %v", ctx.Err())
+				return
+			}
+			i++
+			log.Printf("Forwarding message %d to subscribers...", i)
+			for _, subCh := range subscribers {
+				select {
+				case subCh <- msg:
+				case <-ctx.Done():
+					log.Printf("Exiting fanout goroutine: %v", ctx.Err())
+					return
+				}
+			}
+		}
+	}(ctx)
 
 	// Listen for messages
 	go func(ctx context.Context) {
 		for {
 			select {
-			case msg := <-ch:
-				log.Printf("Received message: %q", msg)
+			case msg := <-subCh1:
+				log.Printf("Received message on sub1: %q", msg)
 			case <-ctx.Done():
-				log.Printf("Exiting listener: %v", ctx.Err())
+				log.Printf("Exiting listener 1: %v", ctx.Err())
 				return
 			}
 			time.Sleep(500 * time.Millisecond)
+		}
+	}(ctx)
+
+	// Listen for messages
+	go func(ctx context.Context) {
+		for {
+			select {
+			case msg := <-subCh2:
+				log.Printf("Received message on sub2: %q", msg)
+			case <-ctx.Done():
+				log.Printf("Exiting listener 2: %v", ctx.Err())
+				return
+			}
 		}
 	}(ctx)
 
@@ -37,7 +77,7 @@ PublishLoop:
 		log.Printf("Sending message %d...", i)
 		select {
 		// Channel writing can be a branch of a select as well as channel reading.
-		case ch <- msg:
+		case pubCh <- msg:
 		case <-ctx.Done():
 			log.Printf("Canceling channel write: %v", ctx.Err())
 			break PublishLoop

--- a/main.go
+++ b/main.go
@@ -2,30 +2,46 @@
 package main
 
 import (
+	"context"
 	"log"
 	"time"
 )
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	ch := make(chan string)
 
 	// Listen for messages
-	go func() {
+	go func(ctx context.Context) {
 		for {
-			msg := <-ch
-			log.Printf("Received message: %q", msg)
+			select {
+			case msg := <-ch:
+				log.Printf("Received message: %q", msg)
+			case <-ctx.Done():
+				log.Printf("Exiting listener: %v", ctx.Err())
+				return
+			}
 			time.Sleep(500 * time.Millisecond)
 		}
-	}()
+	}(ctx)
 
 	// Publish the messages
 	messages := []string{
 		"foo", "bar", "baz", "abc", "def",
 	}
+PublishLoop:
 	for i, msg := range messages {
 		log.Printf("Sending message %d...", i)
-		ch <- msg
+		select {
+		// Channel writing can be a branch of a select as well as channel reading.
+		case ch <- msg:
+		case <-ctx.Done():
+			log.Printf("Canceling channel write: %v", ctx.Err())
+			break PublishLoop
+		}
 	}
 	// Extra sleep to let the listener receive the last message.
 	time.Sleep(500 * time.Millisecond)

--- a/main.go
+++ b/main.go
@@ -7,39 +7,58 @@ import (
 	"time"
 )
 
+type pubSubRunner struct {
+	// Arrows in the type annotation protect us from accidentally writing back into the Publisher
+	Publisher   <-chan string
+	Subscribers []chan<- string
+}
+
+func (ps pubSubRunner) Run(ctx context.Context) {
+	i := 0
+	for {
+		var msg string
+		// Receive from publisher
+		select {
+		case msg = <-ps.Publisher:
+		case <-ctx.Done():
+			log.Printf("Exiting fanout goroutine: %v", ctx.Err())
+			return
+		}
+		i++
+		// Fanout
+		log.Printf("Forwarding message %d to subscribers...", i)
+		for _, subCh := range ps.Subscribers {
+			select {
+			case subCh <- msg:
+			case <-ctx.Done():
+				log.Printf("Exiting fanout goroutine: %v", ctx.Err())
+				return
+			}
+		}
+	}
+}
+
+// RunPubSub creates a publisher channel which, when written to, fans the message out to all provided subscribers.
+//
+// It spawns a goroutine to manage the fanout. The publisher channel is unbuffered, therefore it is throttled by the slowest subscriber.
+func RunPubSub(ctx context.Context, subscribers ...chan<- string) chan<- string {
+	publisher := make(chan string)
+	ps := pubSubRunner{
+		Publisher:   publisher,
+		Subscribers: subscribers,
+	}
+	go ps.Run(ctx)
+	return publisher
+}
+
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	pubCh := make(chan string)
 	subCh1 := make(chan string)
 	subCh2 := make(chan string)
-	subscribers := []chan string{subCh1, subCh2}
-
-	// Fanout the messages:
-	go func(ctx context.Context) {
-		i := 0
-		for {
-			var msg string
-			select {
-			case msg = <-pubCh:
-			case <-ctx.Done():
-				log.Printf("Exiting fanout goroutine: %v", ctx.Err())
-				return
-			}
-			i++
-			log.Printf("Forwarding message %d to subscribers...", i)
-			for _, subCh := range subscribers {
-				select {
-				case subCh <- msg:
-				case <-ctx.Done():
-					log.Printf("Exiting fanout goroutine: %v", ctx.Err())
-					return
-				}
-			}
-		}
-	}(ctx)
+	pubCh := RunPubSub(ctx, subCh1, subCh2)
 
 	// Listen for messages
 	go func(ctx context.Context) {

--- a/main.go
+++ b/main.go
@@ -42,15 +42,16 @@ func main() {
 	wg.Add(1)
 	go func(ctx context.Context) {
 		defer wg.Done()
-		for {
-			select {
-			case msg := <-subCh2:
-				log.Printf("Received message on sub2: %q", msg)
-			case <-ctx.Done():
-				log.Printf("Exiting listener 2: %v", ctx.Err())
-				return
-			}
+		select {
+		case msg := <-subCh2:
+			log.Printf("Received message on sub2: %q", msg)
+		case <-ctx.Done():
+			log.Printf("Exiting listener 2: %v", ctx.Err())
+			return
 		}
+		// Return after the first message is received.
+		// We see that this breaks the other subscriber,
+		// which is probably not the behavior we want
 	}(ctx)
 
 	// Publish the messages

--- a/pubsub/runner.go
+++ b/pubsub/runner.go
@@ -18,7 +18,16 @@ func (ps pubSubRunner) Run(ctx context.Context) {
 		var msg string
 		// Receive from publisher
 		select {
-		case msg = <-ps.Publisher:
+		case m, ok := <-ps.Publisher:
+			if !ok {
+				log.Printf("Exiting fanout on pubsub closure")
+				// We could loop throush the subscribers here and call close(subCh) here,
+				// but I don't think that's safe, since closing a channel after write causes a panic.
+				// The subscriber channels are provided to RunPubSub by the client,
+				// so we can't prevent the client from attempting to write to the channel after write.
+				return
+			}
+			msg = m
 		case <-ctx.Done():
 			log.Printf("Exiting fanout goroutine: %v", ctx.Err())
 			return
@@ -39,13 +48,18 @@ func (ps pubSubRunner) Run(ctx context.Context) {
 
 // RunPubSub creates a publisher channel which, when written to, fans the message out to all provided subscribers.
 //
+// In addition to the data channel, it returns a done channel, which signals when the runner has closed.
 // It spawns a goroutine to manage the fanout. The publisher channel is unbuffered, therefore it is throttled by the slowest subscriber.
-func RunPubSub(ctx context.Context, subscribers ...chan<- string) chan<- string {
+func RunPubSub(ctx context.Context, subscribers ...chan<- string) (chan<- string, <-chan struct{}) {
 	publisher := make(chan string)
 	ps := pubSubRunner{
 		Publisher:   publisher,
 		Subscribers: subscribers,
 	}
-	go ps.Run(ctx)
-	return publisher
+	done := make(chan struct{}, 1)
+	go func() {
+		ps.Run(ctx)
+		done <- struct{}{}
+	}()
+	return publisher, done
 }

--- a/pubsub/runner.go
+++ b/pubsub/runner.go
@@ -1,0 +1,51 @@
+// Package pubsub extracts the pubsub demo into a library.
+package pubsub
+
+import (
+	"context"
+	"log"
+)
+
+type pubSubRunner struct {
+	// Arrows in the type annotation protect us from accidentally writing back into the Publisher
+	Publisher   <-chan string
+	Subscribers []chan<- string
+}
+
+func (ps pubSubRunner) Run(ctx context.Context) {
+	i := 0
+	for {
+		var msg string
+		// Receive from publisher
+		select {
+		case msg = <-ps.Publisher:
+		case <-ctx.Done():
+			log.Printf("Exiting fanout goroutine: %v", ctx.Err())
+			return
+		}
+		i++
+		// Fanout
+		log.Printf("Forwarding message %d to subscribers...", i)
+		for _, subCh := range ps.Subscribers {
+			select {
+			case subCh <- msg:
+			case <-ctx.Done():
+				log.Printf("Exiting fanout goroutine: %v", ctx.Err())
+				return
+			}
+		}
+	}
+}
+
+// RunPubSub creates a publisher channel which, when written to, fans the message out to all provided subscribers.
+//
+// It spawns a goroutine to manage the fanout. The publisher channel is unbuffered, therefore it is throttled by the slowest subscriber.
+func RunPubSub(ctx context.Context, subscribers ...chan<- string) chan<- string {
+	publisher := make(chan string)
+	ps := pubSubRunner{
+		Publisher:   publisher,
+		Subscribers: subscribers,
+	}
+	go ps.Run(ctx)
+	return publisher
+}

--- a/pubsub/runner_test.go
+++ b/pubsub/runner_test.go
@@ -1,0 +1,79 @@
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRunPubSub(t *testing.T) {
+	type testCase struct {
+		numSubs     int
+		numMessages int
+	}
+	testCases := make([]testCase, 0, 16)
+	for numSubs := 0; numSubs < 5; numSubs++ {
+		for messages := 0; messages < 5; messages++ {
+			testCases = append(testCases, testCase{
+				numSubs:     numSubs,
+				numMessages: messages,
+			})
+		}
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-receivers_%d-messages", tc.numSubs, tc.numMessages), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			wg := sync.WaitGroup{}
+
+			subs := make([]chan<- string, tc.numSubs)
+			received := make([][]string, tc.numSubs)
+			for i := 0; i < tc.numSubs; i++ {
+				i := i
+				ch := make(chan string)
+				subs[i] = ch
+				msgs := make([]string, 0, tc.numMessages)
+				wg.Add(1)
+				go func() {
+					defer func() {
+						received[i] = msgs
+						wg.Done()
+					}()
+					for {
+						select {
+						case msg := <-ch:
+							msgs = append(msgs, msg)
+						case <-ctx.Done():
+							return
+						}
+					}
+				}()
+			}
+
+			pubCh, doneCh := RunPubSub(ctx, subs...)
+			published := make([]string, 0, tc.numMessages)
+			for i := 0; i < tc.numMessages; i++ {
+				msg := fmt.Sprintf("Message #%d", i)
+				pubCh <- msg
+				published = append(published, msg)
+			}
+			close(pubCh)
+			<-doneCh
+			cancel()
+			wg.Wait()
+
+			for i := 0; i < tc.numSubs; i++ {
+				if recvd := len(received[i]); recvd != tc.numMessages {
+					t.Errorf("Receiver[%d] received %d messages; want %d", i, recvd, tc.numMessages)
+				}
+				if diff := cmp.Diff(published, received[i]); diff != "" {
+					t.Errorf("Receiver[%d] did not receive the published messages (-want +got)\n%s", i, diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is the initial implementation. It's a pretty good sandbox for playing around with goroutines, channels, and a bit of `sync.WaitGroup`, but it has limitations, some of which I try to illustrate here, some of which will be more apparent in the other implementation.

You can go through this commit-by-commit, and check out any commit as a sandbox starting point, and it should be a somewhat instructive learning path.
1. [Add context awareness](https://github.com/mwiczer/pubsub-demo/commit/b67f58633187e6fc12cd18c0ba552347c22f0541)
    - Since `context` is just a package in the standard library and not a language feature, it's not really discussed in things like the Go tour, but I think it's very helpful for good go concurrency.
3. [Hardcode a second subscriber](https://github.com/mwiczer/pubsub-demo/commit/2af3c961bf94f62308b2f91228acd5a0376e6cb2)
    - Start to code up the fan-out behavior at the core of pubsub.
4. [Extract the PubSub fanout runner](https://github.com/mwiczer/pubsub-demo/commit/ef730d79fc53ae09999b61c651fd02b6e8292d5e) into a struct.
5. [Move current implementation into a library package](https://github.com/mwiczer/pubsub-demo/commit/2898a00eea819c8de26c692a49dff2af434f2846) out of `main.go`e
6. [Finish processing messages without a time.Sleep](https://github.com/mwiczer/pubsub-demo/commit/e36f9160c34d5d6822b85af308e702f02853fd14)
    - This is the first main sign of trouble. It's quite difficult to ensure that the subscribers have finished processing the messages you sent.
    - Introduce channel closure and `sync.WaitGroup`.
7. [Some basic unit test coverage](https://github.com/mwiczer/pubsub-demo/commit/bfe0471ba572e56dde2c633d81a159f2ce8509d5)
8. [If one subscriber exits, it breaks the other subscriber](https://github.com/mwiczer/pubsub-demo/commit/dbd8dab2a6eddbce79da83c4b0c55a85f08cca72)
    - This is another big sign of trouble with this implementation. I can't think of a good way to make the subscriber list dynamic, whch is especially important because processes can die or error out.