### PR TITLE
Implement a "router" style PubSub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/mwiczer/pubsub-demo
 go 1.22.3
 
 require github.com/google/go-cmp v0.6.0
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pubsub/router.go
+++ b/pubsub/router.go
@@ -1,0 +1,41 @@
+package pubsub
+
+import (
+	"context"
+	"log"
+)
+
+// Router provides pubsub behavior by exposing Publish and Subscribe methods.
+//
+// It differs from the runner style in a few ways:
+// 1. There's no "runner" goroutine. One goroutine per subscriber, but no extra one.
+// 2. The relevant channels are made by the Router struct. In contrast, the consumer provdides subscriber channels for the runner.
+// 3. Publishing blocks until fanout is complete.
+//
+// For now, the subscribers list must be static, but I think this architecture gives us a good opportunity to fix that.
+type Router struct {
+	subscribers []chan<- string
+}
+
+// Subscribe registers the provided listener as a subscriber to future published messages.
+//
+// Subscribe spawns a goroutine that lives as long as the listener.
+func (ps *Router) Subscribe(listener func(<-chan string)) {
+	subCh := make(chan string)
+	ps.subscribers = append(ps.subscribers, subCh)
+
+	go listener(subCh)
+	log.Printf("Added subscriber #%d", len(ps.subscribers))
+}
+
+// Publish sends the provided message to all active subscribers.
+func (ps *Router) Publish(ctx context.Context, msg string) error {
+	for _, sub := range ps.subscribers {
+		select {
+		case sub <- msg:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}

--- a/pubsub/router.go
+++ b/pubsub/router.go
@@ -17,37 +17,81 @@ import (
 // 4. "Self-healing". If one subscriber exits, we can still publish to other active subscribers.
 //   - This is still flaky, and not fully robust. We'll need to use something better than sync.Map for that.
 type Router struct {
-	subscribers sync.Map
+	mu          sync.RWMutex
+	subscribers map[uuid.UUID]*subscriber
+}
+
+type subscriber struct {
+	data chan<- string
+	done <-chan struct{}
 }
 
 // Subscribe registers the provided listener as a subscriber to future published messages.
 //
 // Subscribe spawns a goroutine that lives as long as the listener.
 func (ps *Router) Subscribe(listener func(<-chan string)) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.subscribers == nil {
+		ps.subscribers = make(map[uuid.UUID]*subscriber)
+	}
 	subCh := make(chan string)
+	// Done channel is buffered because we know there will be at most one message in the channel.
+	// Writing to the channel can be fast. We shouldn't block, as there may never be a receiver of the message.
+	doneCh := make(chan struct{}, 1)
 	id := uuid.New()
-	ps.subscribers.Store(id, (chan<- string)(subCh))
+	ps.subscribers[id] = &subscriber{
+		data: subCh,
+		done: doneCh,
+	}
 
 	go func() {
 		listener(subCh)
-		ps.subscribers.Delete(id)
-		log.Printf("Removed subscriber %s", id)
+		ps.removeSubscriber(id, doneCh)
 	}()
 	log.Printf("Added subscriber %s", id)
 }
 
+func (ps *Router) removeSubscriber(id uuid.UUID, doneCh chan<- struct{}) {
+	// Writing to the doneCh doesn't need to be in any lock, due to the inherent thread-safety of channels.
+	// I don't _think_ it would be too harmful to put this inside the lock,
+	// but it doesn't hurt to get the removal info out into the fanout loop more eagerly.
+	doneCh <- struct{}{}
+
+	// This doesn't cause a deadlock with the lock acquired in the main body of Subscribe
+	// because we're inside a goroutine. Subscribe can return freely and release its lock before we get here.
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	delete(ps.subscribers, id)
+	log.Printf("Removed subscriber %s", id)
+}
+
 // Publish sends the provided message to all active subscribers.
 func (ps *Router) Publish(ctx context.Context, msg string) error {
-	var err error
-	ps.subscribers.Range(func(_, value any) bool {
-		sub := value.(chan<- string)
+	// Make a read-only copy of the subscribers list. This means that during fanout, we will ignore any new subscribers,
+	// but subscribers _can_ be removed during fanout, due to our use of the done channel.
+	subs := ps.cloneSubscribers()
+
+	log.Printf("Publishing to %d active subscribers...", len(subs))
+	for id, sub := range subs {
 		select {
-		case sub <- msg:
+		case sub.data <- msg:
+		case <-sub.done:
+			// The subscribers list has shrunk since we made our read-only copy.
+			log.Printf("Subscriber %v is done; skipping publish", id)
 		case <-ctx.Done():
-			err = ctx.Err()
-			return false
+			return ctx.Err()
 		}
-		return true
-	})
-	return err
+	}
+	return nil
+}
+
+func (ps *Router) cloneSubscribers() map[uuid.UUID]*subscriber {
+	ps.mu.RLock()
+	subs := make(map[uuid.UUID]*subscriber, len(ps.subscribers))
+	for id, sub := range ps.subscribers {
+		subs[id] = sub
+	}
+	ps.mu.RUnlock()
+	return subs
 }

--- a/pubsub/router_test.go
+++ b/pubsub/router_test.go
@@ -1,0 +1,134 @@
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRouter(t *testing.T) {
+	type testCase struct {
+		numSubs     int
+		numMessages int
+	}
+	testCases := make([]testCase, 0, 16)
+	for numSubs := 0; numSubs < 5; numSubs++ {
+		for messages := 0; messages < 5; messages++ {
+			testCases = append(testCases, testCase{
+				numSubs:     numSubs,
+				numMessages: messages,
+			})
+		}
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-receivers_%d-messages", tc.numSubs, tc.numMessages), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			wg := sync.WaitGroup{}
+
+			ps := &Router{}
+			received := make([][]string, tc.numSubs)
+			for i := 0; i < tc.numSubs; i++ {
+				i := i
+				msgs := make([]string, 0, tc.numMessages)
+				wg.Add(1)
+				ps.Subscribe(func(ch <-chan string) {
+					defer func() {
+						received[i] = msgs
+						wg.Done()
+					}()
+					for {
+						select {
+						case msg := <-ch:
+							msgs = append(msgs, msg)
+						case <-ctx.Done():
+							return
+						}
+					}
+				})
+			}
+
+			published := make([]string, 0, tc.numMessages)
+			for i := 0; i < tc.numMessages; i++ {
+				msg := fmt.Sprintf("Message #%d", i)
+				if err := ps.Publish(ctx, msg); err != nil {
+					t.Errorf("Publish(%q) returned an error: %v", msg, err)
+					break
+				}
+				published = append(published, msg)
+			}
+			cancel()
+			wg.Wait()
+
+			for i := 0; i < tc.numSubs; i++ {
+				if recvd := len(received[i]); recvd != tc.numMessages {
+					t.Errorf("Receiver[%d] received %d messages; want %d", i, recvd, tc.numMessages)
+				}
+				if diff := cmp.Diff(published, received[i]); diff != "" {
+					t.Errorf("Receiver[%d] did not receive the published messages (-want +got)\n%s", i, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestRouter_EarlyExit(t *testing.T) {
+	t.Skip("Unlike with the runner implementation, this passes often, but it's flaky.")
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	numMessages := 10
+	wg := sync.WaitGroup{}
+
+	ps := &Router{}
+	received := make([]string, 0, numMessages)
+	wg.Add(1)
+	ps.Subscribe(func(ch <-chan string) {
+		defer wg.Done()
+		for {
+			select {
+			case msg := <-ch:
+				received = append(received, msg)
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	// This subscriber exits after receiving the first message
+	wg.Add(1)
+
+	ps.Subscribe(func(ch <-chan string) {
+		defer wg.Done()
+		select {
+		case msg := <-ch:
+			log.Printf("Second subscriber exiting after receiving message %q", msg)
+		case <-ctx.Done():
+		}
+	})
+
+	published := make([]string, 0, numMessages)
+	for i := 0; i < numMessages; i++ {
+		msg := fmt.Sprintf("Message #%d", i)
+		if err := ps.Publish(ctx, msg); err != nil {
+			t.Errorf("Publish(%q) returned an error: %v", msg, err)
+			break
+		}
+		published = append(published, msg)
+	}
+	cancel()
+	wg.Wait()
+
+	if recvd := len(received); recvd != numMessages {
+		t.Errorf("Receiver received %d messages; want %d", recvd, numMessages)
+	}
+	if diff := cmp.Diff(published, received); diff != "" {
+		t.Errorf("Receiver did not receive the published messages (-want +got)\n%s", diff)
+	}
+}

--- a/pubsub/router_test.go
+++ b/pubsub/router_test.go
@@ -79,7 +79,6 @@ func TestRouter(t *testing.T) {
 }
 
 func TestRouter_EarlyExit(t *testing.T) {
-	t.Skip("Unlike with the runner implementation, this passes often, but it's flaky.")
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 


### PR DESCRIPTION
I think this is a better option than the "Runner" style (#1). More of the channel and goroutine specifics are hidden in the Router implementation, not exposed to the consumer. 

In the "runner" case, the consumer needs to deal with the publish channel it was provided, it needs to create a channel for each subscribe, a goroutine for each subscriber, etc. IMO this saddles the consumer with a lot of responsibility for thinking about how the pubsub works. The only place where the router implementation exposes the existence of channels or goroutines is that the listener passed to the subscriber gets new messages through a provided channel. The moral of the story is that go concurrency patterns work best when the concurrency primitives are used primarily as implementation details, not exposed as part of the API or contract.

A heuristic that follows from this moral: channels should be provisioned near wherever corresponding goroutines are spawned.

As with the runner PR #1, You can go through this commit-by-commit, and check out any commit as a sandbox starting point, and it should be a somewhat instructive learning path:
1. [Introduce a "router" style PubSub](https://github.com/mwiczer/pubsub-demo/commit/3bb3e20ed5df4bf7e4e413310385cde9df890f78)
2. [Start making the router implementation self-healing](https://github.com/mwiczer/pubsub-demo/commit/f0398d56bc0fc283897594c110d012bb094e67a8)
3. [Safeguard against changes to subscribers list during fanout](https://github.com/mwiczer/pubsub-demo/commit/ceeb249b416307df03eee09223a7593309d582d5)