### PR TITLE
Genericize PubSub

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,19 +15,19 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	ps := &pubsub.Router{}
+	ps := &pubsub.Router[int]{}
 
 	// Use the WaitGroup so make sure we don't exit the binary until the subscribers have successfully processed any context cancellation signal.
 	wg := sync.WaitGroup{}
 
 	// Listen for messages
 	wg.Add(1)
-	ps.Subscribe(func(ch <-chan string) {
+	ps.Subscribe(func(ch <-chan int) {
 		defer wg.Done()
 		for {
 			select {
 			case msg := <-ch:
-				log.Printf("Received message on sub1: %q", msg)
+				log.Printf("Received message on sub1: %d", msg)
 			case <-ctx.Done():
 				log.Printf("Exiting listener 1: %v", ctx.Err())
 				return
@@ -38,24 +38,24 @@ func main() {
 
 	// Listen for messages
 	wg.Add(1)
-	ps.Subscribe(func(ch <-chan string) {
+	ps.Subscribe(func(ch <-chan int) {
 		defer wg.Done()
 		time.Sleep(100 * time.Millisecond)
 		select {
 		case msg := <-ch:
-			log.Printf("Received message on sub2: %q", msg)
+			log.Printf("Received message on sub2: %d", msg)
 		case <-ctx.Done():
 			log.Printf("Exiting listener 2: %v", ctx.Err())
 			return
 		}
 		log.Printf("Spawning nested listener")
 		wg.Add(1)
-		ps.Subscribe(func(ch <-chan string) {
+		ps.Subscribe(func(ch <-chan int) {
 			wg.Done()
 			time.Sleep(100 * time.Millisecond)
 			select {
 			case msg := <-ch:
-				log.Printf("Received message on nested subscriber: %q", msg)
+				log.Printf("Received message on nested subscriber: %d", msg)
 			case <-ctx.Done():
 				log.Printf("Exiting nested listener: %v", ctx.Err())
 				return
@@ -67,8 +67,8 @@ func main() {
 	})
 
 	// Publish the messages
-	messages := []string{
-		"foo", "bar", "baz", "abc", "def",
+	messages := []int{
+		999, 99, 9, 111, 123,
 	}
 	for i, msg := range messages {
 		log.Printf("Sending message %d...", i)

--- a/pubsub/router_test.go
+++ b/pubsub/router_test.go
@@ -32,7 +32,7 @@ func TestRouter(t *testing.T) {
 
 			wg := sync.WaitGroup{}
 
-			ps := &Router{}
+			ps := &Router[string]{}
 			received := make([][]string, tc.numSubs)
 			for i := 0; i < tc.numSubs; i++ {
 				i := i
@@ -85,7 +85,7 @@ func TestRouter_EarlyExit(t *testing.T) {
 	numMessages := 10
 	wg := sync.WaitGroup{}
 
-	ps := &Router{}
+	ps := &Router[string]{}
 	received := make([]string, 0, numMessages)
 	wg.Add(1)
 	ps.Subscribe(func(ch <-chan string) {
@@ -102,7 +102,6 @@ func TestRouter_EarlyExit(t *testing.T) {
 
 	// This subscriber exits after receiving the first message
 	wg.Add(1)
-
 	ps.Subscribe(func(ch <-chan string) {
 		defer wg.Done()
 		select {

--- a/pubsub/runner.go
+++ b/pubsub/runner.go
@@ -6,16 +6,16 @@ import (
 	"log"
 )
 
-type pubSubRunner struct {
+type pubSubRunner[T any] struct {
 	// Arrows in the type annotation protect us from accidentally writing back into the Publisher
-	Publisher   <-chan string
-	Subscribers []chan<- string
+	Publisher   <-chan T
+	Subscribers []chan<- T
 }
 
-func (ps pubSubRunner) Run(ctx context.Context) {
+func (ps pubSubRunner[T]) Run(ctx context.Context) {
 	i := 0
 	for {
-		var msg string
+		var msg T
 		// Receive from publisher
 		select {
 		case m, ok := <-ps.Publisher:
@@ -50,9 +50,9 @@ func (ps pubSubRunner) Run(ctx context.Context) {
 //
 // In addition to the data channel, it returns a done channel, which signals when the runner has closed.
 // It spawns a goroutine to manage the fanout. The publisher channel is unbuffered, therefore it is throttled by the slowest subscriber.
-func RunPubSub(ctx context.Context, subscribers ...chan<- string) (chan<- string, <-chan struct{}) {
-	publisher := make(chan string)
-	ps := pubSubRunner{
+func RunPubSub[T any](ctx context.Context, subscribers ...chan<- T) (chan<- T, <-chan struct{}) {
+	publisher := make(chan T)
+	ps := pubSubRunner[T]{
 		Publisher:   publisher,
 		Subscribers: subscribers,
 	}


### PR DESCRIPTION
- And change main.go to use integer messages instead of string messages, to demonstrate that generics have worked.
- Go generics are pretty limited compared to other languages, but IMO this is a textbook example where generics are helpful. The PubSub package is completely agnostic to the type of data it routes.